### PR TITLE
CMake: Replace depcrecated function

### DIFF
--- a/plugins/Readme.md
+++ b/plugins/Readme.md
@@ -102,7 +102,7 @@ FetchContent_MakeAvailable(yaml-cpp)
 # Required because libraries have to be relocatable and can therefore only link with relocatable code
 set_property(TARGET yaml-cpp PROPERTY POSITION_INDEPENDENT_CODE TRUE)
 # Make the function that provides the plugin root node in IPluginConfig available 
-add_definitions(-DYAML_CPP_SUPPORT)
+add_compile_definitions(YAML_CPP_SUPPORT)
 ```
 
 ```c++

--- a/plugins/inmemoryscanner/CMakeLists.txt
+++ b/plugins/inmemoryscanner/CMakeLists.txt
@@ -36,7 +36,7 @@ option(YAML_BUILD_SHARED_LIBS "" OFF)
 option(YAML_CPP_BUILD_TOOLS "" OFF)
 FetchContent_MakeAvailable(yaml-cpp)
 set_property(TARGET yaml-cpp PROPERTY POSITION_INDEPENDENT_CODE TRUE)
-add_definitions(-DYAML_CPP_SUPPORT)
+add_compile_definitions(YAML_CPP_SUPPORT)
 
 # Add public vmicore headers
 
@@ -51,7 +51,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(compile_flags -Wunused -Wunreachable-code -Wall -Wextra -Wpedantic)
 set(libraries vmicore_public_headers ${YARA_LINK_LIBRARIES} yaml-cpp)
 
-add_definitions(-DBUILD_VERSION="${PROGRAM_BUILD_NUMBER}" -DPLUGIN_VERSION="${PROGRAM_VERSION}")
+add_compile_definitions(BUILD_VERSION="${PROGRAM_BUILD_NUMBER}" PLUGIN_VERSION="${PROGRAM_VERSION}")
 
 # End variable section
 

--- a/vmicore/CMakeLists.txt
+++ b/vmicore/CMakeLists.txt
@@ -35,9 +35,9 @@ if (VMI_SANITIZERS)
     endif ()
 endif ()
 
-add_definitions(-DPROGRAM_VERSION="${PROGRAM_VERSION}" -DBUILD_VERSION="${PROGRAM_BUILD_NUMBER}")
+add_compile_definitions(PROGRAM_VERSION="${PROGRAM_VERSION}" BUILD_VERSION="${PROGRAM_BUILD_NUMBER}")
 if (TRACE_MODE)
-    add_definitions(-DTRACE_MODE)
+    add_compile_definitions(TRACE_MODE)
 endif ()
 
 # Check if tclap is present
@@ -83,7 +83,7 @@ option(YAML_CPP_BUILD_TOOLS "" OFF)
 FetchContent_MakeAvailable(yaml-cpp)
 set_property(TARGET yaml-cpp PROPERTY POSITION_INDEPENDENT_CODE TRUE)
 # Enable optional feature from plugin config header in order to be able to implement it
-add_definitions(-DYAML_CPP_SUPPORT)
+add_compile_definitions(YAML_CPP_SUPPORT)
 
 # Setup Boost DI
 


### PR DESCRIPTION
`add_compile_definitions()` is a better fit for adding preprocessor definitions.