### PR TITLE
Update github checkout action

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Run Codacy Analysis CLI
         uses: codacy/codacy-analysis-cli-action@master

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -30,7 +30,7 @@ jobs:
       image: gdatacyberdefense/clang-format:14
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Perform C++ format check
         run: find . -iname *.h -o -iname *.cpp | xargs clang-format --style=file --dry-run --Werror
@@ -41,7 +41,7 @@ jobs:
       image: ghcr.io/gdatasoftwareag/vmi-build
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Test vmicore
         run: |
@@ -64,7 +64,7 @@ jobs:
       image: ghcr.io/gdatasoftwareag/vmi-build
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Build vmicore
         run: |
@@ -88,7 +88,7 @@ jobs:
       image: ghcr.io/gdatasoftwareag/vmi-build
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Test inmemoryscanner
         run: |
@@ -111,7 +111,7 @@ jobs:
       image: ghcr.io/gdatasoftwareag/vmi-build
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Build inmemoryscanner
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: docker/setup-qemu-action@v1
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Annotate commit with clippy warnings
         uses: actions-rs/clippy-check@v1


### PR DESCRIPTION
v3 uses node16 runtime by default instead of the deprecated node12 runtime.