### PR TITLE
Pass `std::string_view` by value

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,8 @@ on:
 jobs:
   rust-lint:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/gdatasoftwareag/vmi-build
 
     steps:
       - uses: actions/checkout@v3

--- a/vmicore/rust_src/Cargo.toml
+++ b/vmicore/rust_src/Cargo.toml
@@ -11,19 +11,19 @@ name = "rust_grpc_server"
 path = "src/main.rs"
 
 [dependencies]
-tonic = "0.6.1"
-prost = "0.9.0"
-prost-types = "0.9.0"
-tokio = { version = "1.10", features = ["macros", "rt-multi-thread", "net"] }
+tonic = "0.8.2"
+prost = "0.11.2"
+prost-types = "0.11.2"
+tokio = { version = "1.22", features = ["macros", "rt-multi-thread", "net"] }
 cxx = "1.0"
 triggered = "0.1.2"
-async-std = "1.9"
-async-stream = "0.3.2"
-futures-core = "0.3.16"
-chrono = "0.4.19"
+async-std = "1.12"
+async-stream = "0.3.3"
+futures-core = "0.3.25"
+chrono = "0.4.23"
 thiserror = "1"
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 
 [build-dependencies]
-tonic-build = "0.6.0"
+tonic-build = "0.8.2"
 cxx-build = "1.0"

--- a/vmicore/rust_src/src/bridge.rs
+++ b/vmicore/rust_src/src/bridge.rs
@@ -6,6 +6,7 @@ use crate::grpc_server::{new_server, GRPCServer};
 use crate::logging::*;
 
 #[cxx::bridge]
+#[allow(warnings)]
 pub mod ffi {
     #[namespace = "logging"]
     #[derive(Debug, PartialOrd)]
@@ -24,14 +25,14 @@ pub mod ffi {
 
     #[namespace = "logging"]
     extern "Rust" {
-        fn convert_to_log_level(level: &CxxString) -> Result<Level>;
+        fn convert_to_log_level(level: &str) -> Result<Level>;
 
         type LogField;
-        fn field_str(name: &CxxString, val: &CxxString) -> Box<LogField>;
-        fn field_i64(name: &CxxString, val: i64) -> Box<LogField>;
-        fn field_float64(name: &CxxString, val: f64) -> Box<LogField>;
-        fn field_uint64(name: &CxxString, val: u64) -> Box<LogField>;
-        fn field_bool(name: &CxxString, val: bool) -> Box<LogField>;
+        fn field_str(name: &str, val: &str) -> Box<LogField>;
+        fn field_i64(name: &str, val: i64) -> Box<LogField>;
+        fn field_float64(name: &str, val: f64) -> Box<LogField>;
+        fn field_uint64(name: &str, val: u64) -> Box<LogField>;
+        fn field_bool(name: &str, val: bool) -> Box<LogField>;
     }
 
     #[namespace = "logging::grpc"]
@@ -39,7 +40,7 @@ pub mod ffi {
         type GrpcLogger;
 
         fn bind(self: &mut GrpcLogger, log_fields: &[Box<LogField>]);
-        fn log(self: &GrpcLogger, level: Level, message: String, fields: &[Box<LogField>]) -> Result<()>;
+        fn log(self: &GrpcLogger, level: Level, message: &str, fields: &[Box<LogField>]) -> Result<()>;
     }
 
     #[namespace = "logging::console"]
@@ -51,34 +52,34 @@ pub mod ffi {
         fn set_log_level(self: &mut ConsoleLoggerBuilder, log_level: Level);
 
         fn new_logger(self: &ConsoleLoggerBuilder) -> Box<ConsoleLogger>;
-        fn new_named_logger(self: &ConsoleLoggerBuilder, name: &CxxString) -> Box<ConsoleLogger>;
+        fn new_named_logger(self: &ConsoleLoggerBuilder, name: &str) -> Box<ConsoleLogger>;
         fn bind(self: &mut ConsoleLogger, log_fields: &[Box<LogField>]);
-        fn log(self: &ConsoleLogger, level: Level, message: String, fields: &[Box<LogField>]) -> Result<()>;
+        fn log(self: &ConsoleLogger, level: Level, message: &str, fields: &[Box<LogField>]) -> Result<()>;
     }
 
     #[namespace = "grpc"]
     extern "Rust" {
         type GRPCServer;
-        fn new_server(listenAddr: &CxxString, enable_debug: bool) -> Box<GRPCServer>;
+        fn new_server(listenAddr: &str, enable_debug: bool) -> Box<GRPCServer>;
         fn start_server(self: &mut GRPCServer) -> Result<()>;
         fn stop_server(self: &GRPCServer, timeout_millis: u64);
 
         fn new_logger(self: &GRPCServer) -> Box<GrpcLogger>;
-        fn new_named_logger(self: &GRPCServer, name: &CxxString) -> Box<GrpcLogger>;
+        fn new_named_logger(self: &GRPCServer, name: &str) -> Box<GrpcLogger>;
         fn set_log_level(self: &mut GRPCServer, log_level: Level);
 
-        fn write_message_to_file(self: &GRPCServer, name: &CxxString, message: &CxxVector<u8>) -> Result<()>;
+        fn write_message_to_file(self: &GRPCServer, name: &str, message: &CxxVector<u8>) -> Result<()>;
         fn send_process_event(
             self: &GRPCServer,
             process_state: ProcessState,
-            process_name: &CxxString,
+            process_name: &str,
             process_id: u32,
-            cr3: &CxxString,
+            cr3: &str,
         ) -> Result<()>;
         fn send_bsod_event(self: &GRPCServer, code: i64) -> Result<()>;
         fn send_ready_event(self: &GRPCServer) -> Result<()>;
         fn send_termination_event(self: &GRPCServer) -> Result<()>;
-        fn send_error_event(self: &GRPCServer, message: &CxxString) -> Result<()>;
-        fn send_in_mem_detection_event(self: &GRPCServer, message: &CxxString) -> Result<()>;
+        fn send_error_event(self: &GRPCServer, message: &str) -> Result<()>;
+        fn send_in_mem_detection_event(self: &GRPCServer, message: &str) -> Result<()>;
     }
 }

--- a/vmicore/rust_src/src/console_logger.rs
+++ b/vmicore/rust_src/src/console_logger.rs
@@ -1,7 +1,6 @@
 use std::error::Error;
 
 use chrono::Utc;
-use cxx::CxxString;
 
 use crate::bridge::ffi::Level;
 use crate::hive_operations::logging::{log_field::Field, LogField};
@@ -22,7 +21,7 @@ impl ConsoleLoggerBuilder {
         })
     }
 
-    pub fn new_named_logger(&self, name: &CxxString) -> Box<ConsoleLogger> {
+    pub fn new_named_logger(&self, name: &str) -> Box<ConsoleLogger> {
         let log_field = LogField {
             name: "logger".to_string(),
             field: Some(Field::StrField(name.to_string())),
@@ -51,7 +50,7 @@ impl ConsoleLogger {
     pub fn log(
         self: &ConsoleLogger,
         level: Level,
-        message: String,
+        message: &str,
         fields: &[Box<LogField>],
     ) -> Result<(), Box<dyn Error>> {
         if level < self.log_level {

--- a/vmicore/rust_src/src/grpc_logger.rs
+++ b/vmicore/rust_src/src/grpc_logger.rs
@@ -34,12 +34,7 @@ impl GrpcLogger {
         self.base_fields.extend(log_fields.iter().cloned().map(|v| *v));
     }
 
-    pub fn log(
-        self: &GrpcLogger,
-        level: Level,
-        message: String,
-        fields: &[Box<LogField>],
-    ) -> Result<(), Box<dyn Error>> {
+    pub fn log(self: &GrpcLogger, level: Level, message: &str, fields: &[Box<LogField>]) -> Result<(), Box<dyn Error>> {
         if self.sender.is_closed() {
             return Err(Box::new(LogError::LoggingClosedError));
         }
@@ -67,7 +62,7 @@ impl GrpcLogger {
         task::block_on(self.sender.send(LogMessage {
             time_unix: Utc::now().timestamp() as u64,
             level: Into::<LogLevel>::into(level) as i32,
-            msg: message,
+            msg: message.to_string(),
             fields: combined_fields,
         }))?;
         Ok(())

--- a/vmicore/rust_src/src/lib.rs
+++ b/vmicore/rust_src/src/lib.rs
@@ -8,6 +8,7 @@ mod logging;
 mod unix_socket;
 
 pub mod hive_operations {
+    #![allow(clippy::derive_partial_eq_without_eq)]
     pub mod logging {
         pub mod service {
             tonic::include_proto!("hive_operations.logging.service");

--- a/vmicore/rust_src/src/logging.rs
+++ b/vmicore/rust_src/src/logging.rs
@@ -4,7 +4,6 @@ use crate::{
     bridge::ffi::Level,
     hive_operations::logging::{log_field::Field, LogField},
 };
-use cxx::CxxString;
 
 #[derive(thiserror::Error, Debug)]
 pub enum LogError {
@@ -12,34 +11,33 @@ pub enum LogError {
     LogLevelParseError,
 }
 
-pub fn convert_to_log_level(level: &CxxString) -> Result<Level, Box<dyn std::error::Error>> {
-    match level.to_str() {
-        Ok("debug") => Ok(Level::DEBUG),
-        Ok("info") => Ok(Level::INFO),
-        Ok("warning") => Ok(Level::WARN),
-        Ok("error") => Ok(Level::ERROR),
-        Err(e) => Err(Box::new(e)),
+pub fn convert_to_log_level(level: &str) -> Result<Level, Box<dyn std::error::Error>> {
+    match level {
+        "debug" => Ok(Level::DEBUG),
+        "info" => Ok(Level::INFO),
+        "warning" => Ok(Level::WARN),
+        "error" => Ok(Level::ERROR),
         _ => Err(Box::new(LogError::LogLevelParseError)),
     }
 }
 
-pub fn field_str(name: &CxxString, val: &CxxString) -> Box<LogField> {
+pub fn field_str(name: &str, val: &str) -> Box<LogField> {
     new_field(name.to_string(), Field::StrField(val.to_string()))
 }
 
-pub fn field_i64(name: &CxxString, val: i64) -> Box<LogField> {
+pub fn field_i64(name: &str, val: i64) -> Box<LogField> {
     new_field(name.to_string(), Field::IntField(val))
 }
 
-pub fn field_float64(name: &CxxString, val: f64) -> Box<LogField> {
+pub fn field_float64(name: &str, val: f64) -> Box<LogField> {
     new_field(name.to_string(), Field::FloatField(val))
 }
 
-pub fn field_uint64(name: &CxxString, val: u64) -> Box<LogField> {
+pub fn field_uint64(name: &str, val: u64) -> Box<LogField> {
     new_field(name.to_string(), Field::UintField(val))
 }
 
-pub fn field_bool(name: &CxxString, val: bool) -> Box<LogField> {
+pub fn field_bool(name: &str, val: bool) -> Box<LogField> {
     new_field(name.to_string(), Field::BoolField(val))
 }
 

--- a/vmicore/rust_src/src/main.rs
+++ b/vmicore/rust_src/src/main.rs
@@ -10,6 +10,7 @@ mod unix_socket;
 use crate::grpc_server::new_server;
 
 pub mod hive_operations {
+    #![allow(clippy::derive_partial_eq_without_eq)]
     pub mod logging {
         pub mod service {
             tonic::include_proto!("hive_operations.logging.service");
@@ -22,11 +23,11 @@ pub mod hive_operations {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    cxx::let_cxx_string!(addr = "/mnt/rust/vmi.sock");
-    cxx::let_cxx_string!(name = "FancyLogger");
+    let addr = "/mnt/rust/vmi.sock";
+    let name = "FancyLogger";
 
-    let srv = new_server(&addr, false);
-    let logger = srv.new_named_logger(&name);
+    let srv = new_server(addr, false);
+    let logger = srv.new_named_logger(name);
     let srv_handle = std::sync::Arc::new(srv);
 
     println!("Starting server...");
@@ -37,7 +38,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     });
 
     println!("Writing log line");
-    logger.log(bridge::ffi::Level::INFO, "Hello World".to_string(), &[])?;
+    logger.log(bridge::ffi::Level::INFO, "Hello World", &[])?;
 
     println!("Wait for input...");
     std::io::stdin().read_line(&mut String::new())?;

--- a/vmicore/src/include/vmicore/plugins/PluginInterface.h
+++ b/vmicore/src/include/vmicore/plugins/PluginInterface.h
@@ -60,9 +60,9 @@ namespace VmiCore::Plugin
 
         virtual void logMessage(LogLevel logLevel, const std::string& filename, const std::string& message) const = 0;
 
-        virtual void sendErrorEvent(const std::string_view& message) const = 0;
+        virtual void sendErrorEvent(std::string_view message) const = 0;
 
-        virtual void sendInMemDetectionEvent(const std::string_view& message) const = 0;
+        virtual void sendInMemDetectionEvent(std::string_view message) const = 0;
 
         [[nodiscard]] virtual std::shared_ptr<IIntrospectionAPI> getIntrospectionAPI() const = 0;
 

--- a/vmicore/src/lib/io/IEventStream.h
+++ b/vmicore/src/lib/io/IEventStream.h
@@ -1,7 +1,7 @@
 #ifndef VMICORE_IEVENTSTREAM_H
 #define VMICORE_IEVENTSTREAM_H
 
-#include "cxxbridge/rust_grpc_server/src/bridge.rs.h"
+#include <cxxbridge/rust_grpc_server/src/bridge.rs.h>
 #include <memory>
 #include <string_view>
 #include <vector>
@@ -14,14 +14,19 @@ namespace VmiCore
         virtual ~IEventStream() = default;
 
         virtual void sendProcessEvent(::grpc::ProcessState processState,
-                                      const std::string_view& processName,
+                                      std::string_view processName,
                                       uint32_t processID,
-                                      const std::string_view& cr3) = 0;
+                                      std::string_view cr3) = 0;
+
         virtual void sendBSODEvent(int64_t code) = 0;
+
         virtual void sendReadyEvent() = 0;
+
         virtual void sendTerminationEvent() = 0;
-        virtual void sendErrorEvent(const std::string_view& message) = 0;
-        virtual void sendInMemDetectionEvent(const std::string_view& message) = 0;
+
+        virtual void sendErrorEvent(std::string_view message) = 0;
+
+        virtual void sendInMemDetectionEvent(std::string_view message) = 0;
 
       protected:
         IEventStream() = default;

--- a/vmicore/src/lib/io/IFileTransport.h
+++ b/vmicore/src/lib/io/IFileTransport.h
@@ -12,7 +12,7 @@ namespace VmiCore
       public:
         virtual ~IFileTransport() = default;
 
-        virtual void saveBinaryToFile(const std::string_view& logFileName, const std::vector<uint8_t>& data) = 0;
+        virtual void saveBinaryToFile(std::string_view logFileName, const std::vector<uint8_t>& data) = 0;
 
       protected:
         IFileTransport() = default;

--- a/vmicore/src/lib/io/ILogger.h
+++ b/vmicore/src/lib/io/ILogger.h
@@ -1,8 +1,9 @@
 #ifndef VMICORE_ILOGGER_H
 #define VMICORE_ILOGGER_H
 
-#include "cxxbridge/rust/cxx.h"
-#include "cxxbridge/rust_grpc_server/src/bridge.rs.h"
+#include "RustStr.h"
+#include <cxxbridge/rust/cxx.h>
+#include <cxxbridge/rust_grpc_server/src/bridge.rs.h>
 #include <memory>
 #include <string_view>
 
@@ -14,29 +15,34 @@ namespace VmiCore
 
     namespace logfield
     {
-        inline ::rust::Box<::logging::LogField> create(const std::string_view& key, const std::string_view& val)
+        inline ::rust::Box<::logging::LogField> create(std::string_view key, std::string_view val)
         {
-            return ::logging::field_str(static_cast<std::string>(key), static_cast<std::string>(val));
+            return ::logging::field_str(toRustStr(key), toRustStr(val));
         }
-        inline ::rust::Box<::logging::LogField> create(const std::string_view& key, const char* val)
+
+        inline ::rust::Box<::logging::LogField> create(std::string_view key, const char* val)
         {
-            return ::logging::field_str(static_cast<std::string>(key), val);
+            return ::logging::field_str(toRustStr(key), val);
         }
-        inline ::rust::Box<::logging::LogField> create(const std::string_view& key, const bool& val)
+
+        inline ::rust::Box<::logging::LogField> create(std::string_view key, const bool& val)
         {
-            return ::logging::field_bool(static_cast<std::string>(key), val);
+            return ::logging::field_bool(toRustStr(key), val);
         }
-        inline ::rust::Box<::logging::LogField> create(const std::string_view& key, const int64_t& val)
+
+        inline ::rust::Box<::logging::LogField> create(std::string_view key, const int64_t& val)
         {
-            return ::logging::field_i64(static_cast<std::string>(key), val);
+            return ::logging::field_i64(toRustStr(key), val);
         }
-        inline ::rust::Box<::logging::LogField> create(const std::string_view& key, const uint64_t& val)
+
+        inline ::rust::Box<::logging::LogField> create(std::string_view key, const uint64_t& val)
         {
-            return ::logging::field_uint64(static_cast<std::string>(key), val);
+            return ::logging::field_uint64(toRustStr(key), val);
         }
-        inline ::rust::Box<::logging::LogField> create(const std::string_view& key, const double& val)
+
+        inline ::rust::Box<::logging::LogField> create(std::string_view key, const double& val)
         {
-            return ::logging::field_float64(static_cast<std::string>(key), val);
+            return ::logging::field_float64(toRustStr(key), val);
         }
     }
 
@@ -46,20 +52,20 @@ namespace VmiCore
         virtual ~ILogger() = default;
         virtual void bind(const std::initializer_list<rust::Box<::logging::LogField>>& fields) = 0;
 
-        virtual void debug(const std::string_view& message) const = 0;
-        virtual void debug(const std::string_view& message,
+        virtual void debug(std::string_view message) const = 0;
+        virtual void debug(std::string_view message,
                            const std::initializer_list<rust::Box<::logging::LogField>>& fields) const = 0;
 
-        virtual void info(const std::string_view& message) const = 0;
-        virtual void info(const std::string_view& message,
+        virtual void info(std::string_view message) const = 0;
+        virtual void info(std::string_view message,
                           const std::initializer_list<rust::Box<::logging::LogField>>& fields) const = 0;
 
-        virtual void warning(const std::string_view& message) const = 0;
-        virtual void warning(const std::string_view& message,
+        virtual void warning(std::string_view message) const = 0;
+        virtual void warning(std::string_view message,
                              const std::initializer_list<rust::Box<::logging::LogField>>& fields) const = 0;
 
-        virtual void error(const std::string_view& message) const = 0;
-        virtual void error(const std::string_view& message,
+        virtual void error(std::string_view message) const = 0;
+        virtual void error(std::string_view message,
                            const std::initializer_list<rust::Box<::logging::LogField>>& fields) const = 0;
 
       protected:

--- a/vmicore/src/lib/io/ILogging.h
+++ b/vmicore/src/lib/io/ILogging.h
@@ -2,7 +2,7 @@
 #define VMICORE_ILOGGING_H
 
 #include "ILogger.h"
-#include "cxxbridge/rust_grpc_server/src/bridge.rs.h"
+#include <cxxbridge/rust_grpc_server/src/bridge.rs.h>
 #include <memory>
 #include <string_view>
 
@@ -12,10 +12,15 @@ namespace VmiCore
     {
       public:
         virtual ~ILogging() = default;
+
         virtual void start() = 0;
+
         virtual void stop(const uint64_t& timeoutMillis) = 0;
+
         virtual std::unique_ptr<ILogger> newLogger() = 0;
-        virtual std::unique_ptr<ILogger> newNamedLogger(const std::string_view& name) = 0;
+
+        virtual std::unique_ptr<ILogger> newNamedLogger(std::string_view name) = 0;
+
         virtual void setLogLevel(::logging::Level level) = 0;
 
       protected:

--- a/vmicore/src/lib/io/RustStr.h
+++ b/vmicore/src/lib/io/RustStr.h
@@ -1,0 +1,15 @@
+#ifndef VMICORE_RUSTSTR_H
+#define VMICORE_RUSTSTR_H
+
+#include <cxxbridge/rust/cxx.h>
+#include <string_view>
+
+namespace VmiCore
+{
+    inline ::rust::Str toRustStr(std::string_view stringView)
+    {
+        return {stringView.data(), stringView.size()};
+    }
+}
+
+#endif // VMICORE_RUSTSTR_H

--- a/vmicore/src/lib/io/console/ConsoleLogger.cpp
+++ b/vmicore/src/lib/io/console/ConsoleLogger.cpp
@@ -9,36 +9,36 @@ namespace VmiCore
         logger->bind(rust::Slice<const ::rust::Box<::logging::LogField>>(std::data(fields), fields.size()));
     }
 
-    void ConsoleLogger::debug(const std::string_view& message,
+    void ConsoleLogger::debug(std::string_view message,
                               const std::initializer_list<rust::Box<::logging::LogField>>& fields) const
     {
         logger->log(::logging::Level::DEBUG,
-                    static_cast<std::string>(message),
+                    toRustStr(message),
                     rust::Slice<const ::rust::Box<::logging::LogField>>(std::data(fields), fields.size()));
     }
 
-    void ConsoleLogger::info(const std::string_view& message,
+    void ConsoleLogger::info(std::string_view message,
                              const std::initializer_list<rust::Box<::logging::LogField>>& fields) const
     {
 
         logger->log(::logging::Level::INFO,
-                    static_cast<std::string>(message),
+                    toRustStr(message),
                     rust::Slice<const ::rust::Box<::logging::LogField>>(std::data(fields), fields.size()));
     }
 
-    void ConsoleLogger::warning(const std::string_view& message,
+    void ConsoleLogger::warning(std::string_view message,
                                 const std::initializer_list<rust::Box<::logging::LogField>>& fields) const
     {
         logger->log(::logging::Level::WARN,
-                    static_cast<std::string>(message),
+                    toRustStr(message),
                     rust::Slice<const ::rust::Box<::logging::LogField>>(std::data(fields), fields.size()));
     }
 
-    void ConsoleLogger::error(const std::string_view& message,
+    void ConsoleLogger::error(std::string_view message,
                               const std::initializer_list<rust::Box<::logging::LogField>>& fields) const
     {
         logger->log(::logging::Level::ERROR,
-                    static_cast<std::string>(message),
+                    toRustStr(message),
                     rust::Slice<const ::rust::Box<::logging::LogField>>(std::data(fields), fields.size()));
     }
 }

--- a/vmicore/src/lib/io/console/ConsoleLogger.h
+++ b/vmicore/src/lib/io/console/ConsoleLogger.h
@@ -13,32 +13,32 @@ namespace VmiCore
 
         void bind(const std::initializer_list<rust::Box<::logging::LogField>>& fields) override;
 
-        inline void debug(const std::string_view& message) const override
+        inline void debug(std::string_view message) const override
         {
             debug(message, {});
         };
-        void debug(const std::string_view& message,
+        void debug(std::string_view message,
                    const std::initializer_list<rust::Box<::logging::LogField>>& fields) const override;
 
-        inline void info(const std::string_view& message) const override
+        inline void info(std::string_view message) const override
         {
             info(message, {});
         };
-        void info(const std::string_view& message,
+        void info(std::string_view message,
                   const std::initializer_list<rust::Box<::logging::LogField>>& fields) const override;
 
-        inline void warning(const std::string_view& message) const override
+        inline void warning(std::string_view message) const override
         {
             warning(message, {});
         };
-        void warning(const std::string_view& message,
+        void warning(std::string_view message,
                      const std::initializer_list<rust::Box<::logging::LogField>>& fields) const override;
 
-        inline void error(const std::string_view& message) const override
+        inline void error(std::string_view message) const override
         {
             error(message, {});
         };
-        void error(const std::string_view& message,
+        void error(std::string_view message,
                    const std::initializer_list<rust::Box<::logging::LogField>>& fields) const override;
 
       private:

--- a/vmicore/src/lib/io/console/ConsoleLoggerBuilder.cpp
+++ b/vmicore/src/lib/io/console/ConsoleLoggerBuilder.cpp
@@ -15,10 +15,9 @@ namespace VmiCore
         return std::make_unique<ConsoleLogger>((*consoleLoggerBuilder)->new_logger());
     }
 
-    std::unique_ptr<ILogger> ConsoleLoggerBuilder::newNamedLogger(const std::string_view& name)
+    std::unique_ptr<ILogger> ConsoleLoggerBuilder::newNamedLogger(std::string_view name)
     {
-        return std::make_unique<ConsoleLogger>(
-            (*consoleLoggerBuilder)->new_named_logger(static_cast<std::string>(name)));
+        return std::make_unique<ConsoleLogger>((*consoleLoggerBuilder)->new_named_logger(toRustStr(name)));
     }
 
     void ConsoleLoggerBuilder::setLogLevel(::logging::Level level)

--- a/vmicore/src/lib/io/console/ConsoleLoggerBuilder.h
+++ b/vmicore/src/lib/io/console/ConsoleLoggerBuilder.h
@@ -18,7 +18,7 @@ namespace VmiCore
 
         std::unique_ptr<ILogger> newLogger() override;
 
-        std::unique_ptr<ILogger> newNamedLogger(const std::string_view& name) override;
+        std::unique_ptr<ILogger> newNamedLogger(std::string_view name) override;
 
         void setLogLevel(::logging::Level level) override;
 

--- a/vmicore/src/lib/io/console/DummyEventStream.h
+++ b/vmicore/src/lib/io/console/DummyEventStream.h
@@ -8,9 +8,9 @@ namespace VmiCore
     class DummyEventStream : public IEventStream
     {
         inline void sendProcessEvent([[maybe_unused]] grpc::ProcessState processState,
-                                     [[maybe_unused]] const std::string_view& processName,
+                                     [[maybe_unused]] std::string_view processName,
                                      [[maybe_unused]] uint32_t processID,
-                                     [[maybe_unused]] const std::string_view& cr3) override
+                                     [[maybe_unused]] std::string_view cr3) override
         {
         }
 
@@ -20,9 +20,9 @@ namespace VmiCore
 
         inline void sendReadyEvent() override {}
 
-        inline void sendErrorEvent([[maybe_unused]] const std::string_view& message) override {}
+        inline void sendErrorEvent([[maybe_unused]] std::string_view message) override {}
 
-        inline void sendInMemDetectionEvent([[maybe_unused]] const std::string_view& message) override {}
+        inline void sendInMemDetectionEvent([[maybe_unused]] std::string_view message) override {}
     };
 }
 

--- a/vmicore/src/lib/io/file/LegacyLogging.cpp
+++ b/vmicore/src/lib/io/file/LegacyLogging.cpp
@@ -10,7 +10,7 @@ namespace VmiCore
     {
     }
 
-    void LegacyLogging::saveBinaryToFile(const std::string_view& logFileName, const std::vector<uint8_t>& data)
+    void LegacyLogging::saveBinaryToFile(std::string_view logFileName, const std::vector<uint8_t>& data)
     {
         std::filesystem::create_directories(configInterface->getResultsDirectory());
         std::ofstream ofStream;

--- a/vmicore/src/lib/io/file/LegacyLogging.h
+++ b/vmicore/src/lib/io/file/LegacyLogging.h
@@ -15,7 +15,7 @@ namespace VmiCore
         explicit LegacyLogging(std::shared_ptr<IConfigParser> configInterface);
         ~LegacyLogging() override = default;
 
-        void saveBinaryToFile(const std::string_view& logFileName, const std::vector<uint8_t>& data) override;
+        void saveBinaryToFile(std::string_view logFileName, const std::vector<uint8_t>& data) override;
 
       private:
         std::shared_ptr<IConfigParser> configInterface;

--- a/vmicore/src/lib/io/grpc/GRPCLogger.cpp
+++ b/vmicore/src/lib/io/grpc/GRPCLogger.cpp
@@ -1,10 +1,8 @@
 #include "GRPCLogger.h"
-#include "GRPCServer.h"
-#include "cxxbridge/rust_grpc_server/src/bridge.rs.h"
+#include <cxxbridge/rust_grpc_server/src/bridge.rs.h>
 #include <initializer_list>
 #include <iostream>
 #include <list>
-#include <memory>
 #include <utility>
 
 namespace VmiCore
@@ -16,13 +14,13 @@ namespace VmiCore
         logger->bind(::rust::Slice<const ::rust::Box<::logging::LogField>>(std::data(fields), fields.size()));
     }
 
-    void GRPCLogger::debug(const std::string_view& message,
+    void GRPCLogger::debug(std::string_view message,
                            const std::initializer_list<rust::Box<::logging::LogField>>& fields) const
     {
         try
         {
             logger->log(::logging::Level::DEBUG,
-                        static_cast<std::string>(message),
+                        toRustStr(message),
                         rust::Slice<const ::rust::Box<::logging::LogField>>(std::data(fields), fields.size()));
         }
         catch (const ::rust::Error& e)
@@ -31,13 +29,13 @@ namespace VmiCore
         }
     }
 
-    void GRPCLogger::info(const std::string_view& message,
+    void GRPCLogger::info(std::string_view message,
                           const std::initializer_list<rust::Box<::logging::LogField>>& fields) const
     {
         try
         {
             logger->log(::logging::Level::INFO,
-                        static_cast<std::string>(message),
+                        toRustStr(message),
                         rust::Slice<const ::rust::Box<::logging::LogField>>(std::data(fields), fields.size()));
         }
         catch (const ::rust::Error& e)
@@ -46,13 +44,13 @@ namespace VmiCore
         }
     }
 
-    void GRPCLogger::warning(const std::string_view& message,
+    void GRPCLogger::warning(std::string_view message,
                              const std::initializer_list<rust::Box<::logging::LogField>>& fields) const
     {
         try
         {
             logger->log(::logging::Level::WARN,
-                        static_cast<std::string>(message),
+                        toRustStr(message),
                         rust::Slice<const ::rust::Box<::logging::LogField>>(std::data(fields), fields.size()));
         }
         catch (const ::rust::Error& e)
@@ -61,13 +59,13 @@ namespace VmiCore
         }
     }
 
-    void GRPCLogger::error(const std::string_view& message,
+    void GRPCLogger::error(std::string_view message,
                            const std::initializer_list<rust::Box<::logging::LogField>>& fields) const
     {
         try
         {
             logger->log(::logging::Level::ERROR,
-                        static_cast<std::string>(message),
+                        toRustStr(message),
                         rust::Slice<const ::rust::Box<::logging::LogField>>(std::data(fields), fields.size()));
         }
         catch (const ::rust::Error& e)

--- a/vmicore/src/lib/io/grpc/GRPCLogger.h
+++ b/vmicore/src/lib/io/grpc/GRPCLogger.h
@@ -2,8 +2,8 @@
 #define VMICORE_GRPCLOGGER_H
 
 #include "../ILogger.h"
-#include "cxxbridge/rust/cxx.h"
-#include "cxxbridge/rust_grpc_server/src/bridge.rs.h"
+#include <cxxbridge/rust/cxx.h>
+#include <cxxbridge/rust_grpc_server/src/bridge.rs.h>
 #include <initializer_list>
 #include <memory>
 #include <string>
@@ -18,32 +18,32 @@ namespace VmiCore
 
         void bind(const std::initializer_list<rust::Box<::logging::LogField>>& fields) override;
 
-        inline void debug(const std::string_view& message) const override
+        inline void debug(std::string_view message) const override
         {
             debug(message, {});
         };
-        void debug(const std::string_view& message,
+        void debug(std::string_view message,
                    const std::initializer_list<rust::Box<::logging::LogField>>& fields) const override;
 
-        inline void info(const std::string_view& message) const override
+        inline void info(std::string_view message) const override
         {
             info(message, {});
         };
-        void info(const std::string_view& message,
+        void info(std::string_view message,
                   const std::initializer_list<rust::Box<::logging::LogField>>& fields) const override;
 
-        inline void warning(const std::string_view& message) const override
+        inline void warning(std::string_view message) const override
         {
             warning(message, {});
         };
-        void warning(const std::string_view& message,
+        void warning(std::string_view message,
                      const std::initializer_list<rust::Box<::logging::LogField>>& fields) const override;
 
-        inline void error(const std::string_view& message) const override
+        inline void error(std::string_view message) const override
         {
             error(message, {});
         };
-        void error(const std::string_view& message,
+        void error(std::string_view message,
                    const std::initializer_list<rust::Box<::logging::LogField>>& fields) const override;
 
       private:

--- a/vmicore/src/lib/io/grpc/GRPCServer.cpp
+++ b/vmicore/src/lib/io/grpc/GRPCServer.cpp
@@ -32,9 +32,9 @@ namespace VmiCore
         return std::make_unique<GRPCLogger>((*server)->new_logger());
     }
 
-    std::unique_ptr<ILogger> GRPCServer::newNamedLogger(const std::string_view& name)
+    std::unique_ptr<ILogger> GRPCServer::newNamedLogger(std::string_view name)
     {
-        return std::make_unique<GRPCLogger>((*server)->new_named_logger(static_cast<std::string>(name)));
+        return std::make_unique<GRPCLogger>((*server)->new_named_logger(toRustStr(name)));
     }
 
     void GRPCServer::setLogLevel(::logging::Level level)
@@ -42,18 +42,17 @@ namespace VmiCore
         (*server)->set_log_level(level);
     }
 
-    void GRPCServer::saveBinaryToFile(const std::string_view& logFileName, const std::vector<uint8_t>& data)
+    void GRPCServer::saveBinaryToFile(std::string_view logFileName, const std::vector<uint8_t>& data)
     {
-        (*server)->write_message_to_file(static_cast<std::string>(logFileName), data);
+        (*server)->write_message_to_file(toRustStr(logFileName), data);
     }
 
     void GRPCServer::sendProcessEvent(::grpc::ProcessState processState,
-                                      const std::string_view& processName,
+                                      std::string_view processName,
                                       uint32_t processID,
-                                      const std::string_view& cr3)
+                                      std::string_view cr3)
     {
-        (*server)->send_process_event(
-            processState, static_cast<std::string>(processName), processID, static_cast<std::string>(cr3));
+        (*server)->send_process_event(processState, toRustStr(processName), processID, toRustStr(cr3));
     }
 
     void GRPCServer::sendBSODEvent(int64_t code)
@@ -71,13 +70,13 @@ namespace VmiCore
         (*server)->send_termination_event();
     }
 
-    void GRPCServer::sendErrorEvent(const std::string_view& message)
+    void GRPCServer::sendErrorEvent(std::string_view message)
     {
-        (*server)->send_error_event(static_cast<std::string>(message));
+        (*server)->send_error_event(toRustStr(message));
     }
 
-    void GRPCServer::sendInMemDetectionEvent(const std::string_view& message)
+    void GRPCServer::sendInMemDetectionEvent(std::string_view message)
     {
-        (*server)->send_in_mem_detection_event(static_cast<std::string>(message));
+        (*server)->send_in_mem_detection_event(toRustStr(message));
     }
 }

--- a/vmicore/src/lib/io/grpc/GRPCServer.h
+++ b/vmicore/src/lib/io/grpc/GRPCServer.h
@@ -23,16 +23,16 @@ namespace VmiCore
 
         std::unique_ptr<ILogger> newLogger() override;
 
-        std::unique_ptr<ILogger> newNamedLogger(const std::string_view& name) override;
+        std::unique_ptr<ILogger> newNamedLogger(std::string_view name) override;
 
         void setLogLevel(::logging::Level level) override;
 
-        void saveBinaryToFile(const std::string_view& logFileName, const std::vector<uint8_t>& data) override;
+        void saveBinaryToFile(std::string_view logFileName, const std::vector<uint8_t>& data) override;
 
         void sendProcessEvent(::grpc::ProcessState processState,
-                              const std::string_view& processName,
+                              std::string_view processName,
                               uint32_t processID,
-                              const std::string_view& cr3) override;
+                              std::string_view cr3) override;
 
         void sendBSODEvent(int64_t code) override;
 
@@ -40,9 +40,9 @@ namespace VmiCore
 
         void sendReadyEvent() override;
 
-        void sendErrorEvent(const std::string_view& message) override;
+        void sendErrorEvent(std::string_view message) override;
 
-        void sendInMemDetectionEvent(const std::string_view& message) override;
+        void sendInMemDetectionEvent(std::string_view message) override;
 
       private:
         std::shared_ptr<::rust::Box<grpc::GRPCServer>> server;

--- a/vmicore/src/lib/plugins/PluginSystem.cpp
+++ b/vmicore/src/lib/plugins/PluginSystem.cpp
@@ -179,12 +179,12 @@ namespace VmiCore
         }
     }
 
-    void PluginSystem::sendErrorEvent(const std::string_view& message) const
+    void PluginSystem::sendErrorEvent(std::string_view message) const
     {
         eventStream->sendErrorEvent(message);
     }
 
-    void PluginSystem::sendInMemDetectionEvent(const std::string_view& message) const
+    void PluginSystem::sendInMemDetectionEvent(std::string_view message) const
     {
         eventStream->sendInMemDetectionEvent(message);
     }

--- a/vmicore/src/lib/plugins/PluginSystem.h
+++ b/vmicore/src/lib/plugins/PluginSystem.h
@@ -102,9 +102,9 @@ namespace VmiCore
         void
         logMessage(Plugin::LogLevel logLevel, const std::string& filename, const std::string& message) const override;
 
-        void sendErrorEvent(const std::string_view& message) const override;
+        void sendErrorEvent(std::string_view message) const override;
 
-        void sendInMemDetectionEvent(const std::string_view& message) const override;
+        void sendInMemDetectionEvent(std::string_view message) const override;
 
         [[nodiscard]] std::shared_ptr<IIntrospectionAPI> getIntrospectionAPI() const override;
     };

--- a/vmicore/test/include/vmicore_test/plugins/mock_PluginInterface.h
+++ b/vmicore/test/include/vmicore_test/plugins/mock_PluginInterface.h
@@ -38,9 +38,9 @@ namespace VmiCore::Plugin
 
         MOCK_METHOD(void, logMessage, (LogLevel, const std::string&, const std::string&), (const, override));
 
-        MOCK_METHOD(void, sendErrorEvent, (const std::string_view&), (const, override));
+        MOCK_METHOD(void, sendErrorEvent, (std::string_view), (const, override));
 
-        MOCK_METHOD(void, sendInMemDetectionEvent, (const std::string_view&), (const, override));
+        MOCK_METHOD(void, sendInMemDetectionEvent, (std::string_view), (const, override));
 
         MOCK_METHOD(std::shared_ptr<IIntrospectionAPI>, getIntrospectionAPI, (), (const, override));
     };

--- a/vmicore/test/lib/io/file/mock_LegacyLogging.h
+++ b/vmicore/test/lib/io/file/mock_LegacyLogging.h
@@ -11,7 +11,7 @@ namespace VmiCore
       public:
         MOCK_METHOD(void,
                     saveBinaryToFile,
-                    (const std::string_view& logFileName, const std::vector<uint8_t>& data),
+                    (std::string_view logFileName, const std::vector<uint8_t>& data),
                     (override));
     };
 }

--- a/vmicore/test/lib/io/grpc/mock_GRPCLogger.h
+++ b/vmicore/test/lib/io/grpc/mock_GRPCLogger.h
@@ -11,32 +11,32 @@ namespace VmiCore
       public:
         MOCK_METHOD(void, bind, (const std::initializer_list<::rust::Box<::logging::LogField>>&), (override));
 
-        MOCK_METHOD(void, debug, (const std::string_view&), (const, override));
+        MOCK_METHOD(void, debug, (std::string_view), (const, override));
 
         MOCK_METHOD(void,
                     debug,
-                    (const std::string_view& message, const std::initializer_list<::rust::Box<::logging::LogField>>&),
+                    (std::string_view message, const std::initializer_list<::rust::Box<::logging::LogField>>&),
                     (const, override));
 
-        MOCK_METHOD(void, info, (const std::string_view& message), (const, override));
+        MOCK_METHOD(void, info, (std::string_view message), (const, override));
 
         MOCK_METHOD(void,
                     info,
-                    (const std::string_view& message, const std::initializer_list<::rust::Box<::logging::LogField>>&),
+                    (std::string_view message, const std::initializer_list<::rust::Box<::logging::LogField>>&),
                     (const, override));
 
-        MOCK_METHOD(void, warning, (const std::string_view& message), (const, override));
+        MOCK_METHOD(void, warning, (std::string_view message), (const, override));
 
         MOCK_METHOD(void,
                     warning,
-                    (const std::string_view& message, const std::initializer_list<::rust::Box<::logging::LogField>>&),
+                    (std::string_view message, const std::initializer_list<::rust::Box<::logging::LogField>>&),
                     (const, override));
 
-        MOCK_METHOD(void, error, (const std::string_view& message), (const, override));
+        MOCK_METHOD(void, error, (std::string_view message), (const, override));
 
         MOCK_METHOD(void,
                     error,
-                    (const std::string_view& message, const std::initializer_list<::rust::Box<::logging::LogField>>&),
+                    (std::string_view message, const std::initializer_list<::rust::Box<::logging::LogField>>&),
                     (const, override));
     };
 }

--- a/vmicore/test/lib/io/mock_EventStream.h
+++ b/vmicore/test/lib/io/mock_EventStream.h
@@ -1,7 +1,6 @@
 #ifndef VMICORE_MOCK_EVENTSTREAM_H
 #define VMICORE_MOCK_EVENTSTREAM_H
 
-#include "cxxbridge/rust_grpc_server/src/bridge.rs.h"
 #include <gmock/gmock.h>
 #include <io/IEventStream.h>
 
@@ -12,7 +11,7 @@ namespace VmiCore
       public:
         MOCK_METHOD(void,
                     sendProcessEvent,
-                    (::grpc::ProcessState, const std::string_view&, uint32_t, const std::string_view&),
+                    (::grpc::ProcessState, std::string_view, uint32_t, std::string_view),
                     (override));
 
         MOCK_METHOD(void, sendBSODEvent, (int64_t), (override));
@@ -21,9 +20,9 @@ namespace VmiCore
 
         MOCK_METHOD(void, sendTerminationEvent, (), (override));
 
-        MOCK_METHOD(void, sendErrorEvent, (const std::string_view&), (override));
+        MOCK_METHOD(void, sendErrorEvent, (std::string_view), (override));
 
-        MOCK_METHOD(void, sendInMemDetectionEvent, (const std::string_view&), (override));
+        MOCK_METHOD(void, sendInMemDetectionEvent, (std::string_view), (override));
     };
 }
 

--- a/vmicore/test/lib/io/mock_Logging.h
+++ b/vmicore/test/lib/io/mock_Logging.h
@@ -15,7 +15,7 @@ namespace VmiCore
 
         MOCK_METHOD(std::unique_ptr<ILogger>, newLogger, (), (override));
 
-        MOCK_METHOD(std::unique_ptr<ILogger>, newNamedLogger, (const std::string_view&), (override));
+        MOCK_METHOD(std::unique_ptr<ILogger>, newNamedLogger, (std::string_view), (override));
 
         MOCK_METHOD(void, setLogLevel, (::logging::Level), (override));
     };

--- a/vmicore/test/lib/os/windows/SystemEventSupervisor_UnitTest.cpp
+++ b/vmicore/test/lib/os/windows/SystemEventSupervisor_UnitTest.cpp
@@ -34,7 +34,7 @@ namespace VmiCore
         void SetUp() override
         {
             ON_CALL(*logging, newNamedLogger(_))
-                .WillByDefault([](const std::string_view&) { return std::make_unique<MockGRPCLogger>(); });
+                .WillByDefault([](std::string_view) { return std::make_unique<MockGRPCLogger>(); });
             systemEventSupervisor = std::make_shared<Windows::SystemEventSupervisor>(vmiInterface,
                                                                                      pluginSystem,
                                                                                      activeProcessSupervisor,

--- a/vmicore/test/lib/plugins/PluginSystem_UnitTest.cpp
+++ b/vmicore/test/lib/plugins/PluginSystem_UnitTest.cpp
@@ -280,8 +280,10 @@ namespace VmiCore
             {
                 ON_CALL(*mockVmiInterface, readXVA(memoryRegionInfo.virtualAddress, memoryRegionInfo.cr3, _))
                     .WillByDefault(
-                        [memoryPageContent = memoryRegionInfo.memoryPageContent](
-                            uint64_t virtualAddress, uint64_t cr3, std::vector<uint8_t>& buffer)
+                        [memoryPageContent =
+                             memoryRegionInfo.memoryPageContent]([[maybe_unused]] uint64_t virtualAddress,
+                                                                 [[maybe_unused]] uint64_t cr3,
+                                                                 std::vector<uint8_t>& buffer)
                         {
                             buffer = memoryPageContent;
                             return true;

--- a/vmicore/test/lib/plugins/PluginSystem_UnitTest.cpp
+++ b/vmicore/test/lib/plugins/PluginSystem_UnitTest.cpp
@@ -3,6 +3,7 @@
 #include <memory>
 
 using testing::_;
+using testing::Return;
 using testing::UnorderedElementsAre;
 using testing::Unused;
 

--- a/vmicore/test/lib/plugins/mock_PluginSystem.h
+++ b/vmicore/test/lib/plugins/mock_PluginSystem.h
@@ -37,9 +37,9 @@ namespace VmiCore
 
         MOCK_METHOD(void, logMessage, (Plugin::LogLevel, const std::string&, const std::string&), (const override));
 
-        MOCK_METHOD(void, sendErrorEvent, (const std::string_view&), (const override));
+        MOCK_METHOD(void, sendErrorEvent, (std::string_view), (const override));
 
-        MOCK_METHOD(void, sendInMemDetectionEvent, (const std::string_view&), (const override));
+        MOCK_METHOD(void, sendInMemDetectionEvent, (std::string_view), (const override));
 
         MOCK_METHOD(void,
                     initializePlugin,

--- a/vmicore/test/lib/vmi/InterruptEventSupervisor_UnitTest.cpp
+++ b/vmicore/test/lib/vmi/InterruptEventSupervisor_UnitTest.cpp
@@ -104,7 +104,7 @@ namespace VmiCore
             // Required for InterruptGuard
             ON_CALL(*vmiInterface, readXVA(_, _, _)).WillByDefault(Return(true));
             ON_CALL(*mockLogging, newNamedLogger(_))
-                .WillByDefault([](const std::string_view&) { return std::make_unique<MockGRPCLogger>(); });
+                .WillByDefault([](std::string_view) { return std::make_unique<MockGRPCLogger>(); });
 
             // Gain access to internal interrupt event within InterruptEventSupervisor
             ON_CALL(*vmiInterface, registerEvent(_))

--- a/vmicore/test/lib/vmi/ProcessesMemoryState.h
+++ b/vmicore/test/lib/vmi/ProcessesMemoryState.h
@@ -182,8 +182,8 @@ namespace VmiCore
         {
             std::shared_ptr<testing::NiceMock<MockLogging>> ml = std::make_shared<testing::NiceMock<MockLogging>>();
 
-            ON_CALL(*ml, newNamedLogger(_))
-                .WillByDefault([](const std::string_view&) { return std::make_unique<NiceMock<MockGRPCLogger>>(); });
+            ON_CALL(*ml, newNamedLogger(testing::_))
+                .WillByDefault([](std::string_view) { return std::make_unique<testing::NiceMock<MockGRPCLogger>>(); });
 
             return ml;
         }();

--- a/vmicore/test/lib/vmi/ProcessesMemoryState.h
+++ b/vmicore/test/lib/vmi/ProcessesMemoryState.h
@@ -18,10 +18,6 @@
 #include <os/windows/ProtectionValues.h>
 #include <plugins/PluginSystem.h>
 
-using testing::_;
-using testing::NiceMock;
-using testing::Return;
-
 namespace VmiCore
 {
     namespace _SUBSECTION_OFFSETS
@@ -178,13 +174,13 @@ namespace VmiCore
                                                        0xffffe00172192d10,
                                                        R"(\Windows\System32\csrss.exe)"};
 
-        std::shared_ptr<NiceMock<MockLibvmiInterface>> mockVmiInterface =
-            std::make_shared<NiceMock<MockLibvmiInterface>>();
+        std::shared_ptr<testing::NiceMock<MockLibvmiInterface>> mockVmiInterface =
+            std::make_shared<testing::NiceMock<MockLibvmiInterface>>();
         std::shared_ptr<Windows::KernelAccess> kernelAccess;
 
-        std::shared_ptr<NiceMock<MockLogging>> mockLogging = []()
+        std::shared_ptr<testing::NiceMock<MockLogging>> mockLogging = []()
         {
-            std::shared_ptr<NiceMock<MockLogging>> ml = std::make_shared<NiceMock<MockLogging>>();
+            std::shared_ptr<testing::NiceMock<MockLogging>> ml = std::make_shared<testing::NiceMock<MockLogging>>();
 
             ON_CALL(*ml, newNamedLogger(_))
                 .WillByDefault([](const std::string_view&) { return std::make_unique<NiceMock<MockGRPCLogger>>(); });
@@ -192,104 +188,105 @@ namespace VmiCore
             return ml;
         }();
 
-        std::shared_ptr<NiceMock<MockEventStream>> mockEventStream = std::make_shared<NiceMock<MockEventStream>>();
+        std::shared_ptr<testing::NiceMock<MockEventStream>> mockEventStream =
+            std::make_shared<testing::NiceMock<MockEventStream>>();
 
         std::shared_ptr<Windows::ActiveProcessesSupervisor> activeProcessesSupervisor;
         std::shared_ptr<InterruptEventSupervisor> interruptEventSupervisor;
 
         void setupReturnsForVmiInterface()
         {
-            ON_CALL(*mockVmiInterface, convertPidToDtb(Windows::systemPid)).WillByDefault(Return(systemCR3));
+            ON_CALL(*mockVmiInterface, convertPidToDtb(Windows::systemPid)).WillByDefault(testing::Return(systemCR3));
             ON_CALL(*mockVmiInterface, getKernelStructOffset("_KPROCESS", "DirectoryTableBase"))
-                .WillByDefault(Return(_KPROCESS_OFFSETS::DirectoryTableBase));
+                .WillByDefault(testing::Return(_KPROCESS_OFFSETS::DirectoryTableBase));
             ON_CALL(*mockVmiInterface, getKernelStructOffset("_EPROCESS", "InheritedFromUniqueProcessId"))
-                .WillByDefault(Return(_EPROCESS_OFFSETS::InheritedFromUniqueProcessId));
+                .WillByDefault(testing::Return(_EPROCESS_OFFSETS::InheritedFromUniqueProcessId));
             ON_CALL(*mockVmiInterface, getKernelStructOffset("_EPROCESS", "ImageFileName"))
-                .WillByDefault(Return(_EPROCESS_OFFSETS::ImageFileName));
+                .WillByDefault(testing::Return(_EPROCESS_OFFSETS::ImageFileName));
             ON_CALL(*mockVmiInterface, getKernelStructOffset("_EPROCESS", "UniqueProcessId"))
-                .WillByDefault(Return(_EPROCESS_OFFSETS::UniqueProcessId));
+                .WillByDefault(testing::Return(_EPROCESS_OFFSETS::UniqueProcessId));
             ON_CALL(*mockVmiInterface, getKernelStructOffset("_EPROCESS", "ActiveProcessLinks"))
-                .WillByDefault(Return(_EPROCESS_OFFSETS::ActiveProcessLinks));
+                .WillByDefault(testing::Return(_EPROCESS_OFFSETS::ActiveProcessLinks));
             ON_CALL(*mockVmiInterface, getKernelStructOffset("_EPROCESS", "ExitStatus"))
-                .WillByDefault(Return(_EPROCESS_OFFSETS::ExitStatus));
+                .WillByDefault(testing::Return(_EPROCESS_OFFSETS::ExitStatus));
             ON_CALL(*mockVmiInterface, getKernelStructOffset("_EPROCESS", "SectionObject"))
-                .WillByDefault(Return(_EPROCESS_OFFSETS::SectionObject));
+                .WillByDefault(testing::Return(_EPROCESS_OFFSETS::SectionObject));
             ON_CALL(*mockVmiInterface, getKernelStructOffset("_EPROCESS", "VadRoot"))
-                .WillByDefault(Return(_EPROCESS_OFFSETS::VadRoot));
+                .WillByDefault(testing::Return(_EPROCESS_OFFSETS::VadRoot));
             ON_CALL(*mockVmiInterface, getKernelStructOffset("_EPROCESS", "ImageFilePointer"))
-                .WillByDefault(Return(_EPROCESS_OFFSETS::ImageFilePointer));
+                .WillByDefault(testing::Return(_EPROCESS_OFFSETS::ImageFilePointer));
             ON_CALL(*mockVmiInterface, getKernelStructOffset("_SECTION", "u1"))
-                .WillByDefault(Return(_SECTION_OFFSETS::ControlArea));
+                .WillByDefault(testing::Return(_SECTION_OFFSETS::ControlArea));
             ON_CALL(*mockVmiInterface, getKernelStructOffset("_CONTROL_AREA", "u"))
-                .WillByDefault(Return(_CONTROL_AREA_OFFSETS::MMSECTION_FLAGS));
+                .WillByDefault(testing::Return(_CONTROL_AREA_OFFSETS::MMSECTION_FLAGS));
             ON_CALL(*mockVmiInterface, getKernelStructOffset("_CONTROL_AREA", "FilePointer"))
-                .WillByDefault(Return(_CONTROL_AREA_OFFSETS::FilePointer));
+                .WillByDefault(testing::Return(_CONTROL_AREA_OFFSETS::FilePointer));
             ON_CALL(*mockVmiInterface, getKernelStructOffset("_FILE_OBJECT", "FileName"))
-                .WillByDefault(Return(_FILE_OBJECT_OFFSETS::FileName));
+                .WillByDefault(testing::Return(_FILE_OBJECT_OFFSETS::FileName));
             ON_CALL(*mockVmiInterface, getKernelStructOffset("__MMVAD_SHORT", "VadNode"))
-                .WillByDefault(Return(__MMVAD_SHORT_OFFSETS::VadNode));
+                .WillByDefault(testing::Return(__MMVAD_SHORT_OFFSETS::VadNode));
             ON_CALL(*mockVmiInterface, getKernelStructOffset("_MMVAD_SHORT", "StartingVpn"))
-                .WillByDefault(Return(__MMVAD_SHORT_OFFSETS::StartingVpn));
+                .WillByDefault(testing::Return(__MMVAD_SHORT_OFFSETS::StartingVpn));
             ON_CALL(*mockVmiInterface, getKernelStructOffset("_MMVAD_SHORT", "StartingVpnHigh"))
-                .WillByDefault(Return(__MMVAD_SHORT_OFFSETS::StartingVpnHigh));
+                .WillByDefault(testing::Return(__MMVAD_SHORT_OFFSETS::StartingVpnHigh));
             ON_CALL(*mockVmiInterface, getKernelStructOffset("_MMVAD_SHORT", "EndingVpn"))
-                .WillByDefault(Return(__MMVAD_SHORT_OFFSETS::EndingVpn));
+                .WillByDefault(testing::Return(__MMVAD_SHORT_OFFSETS::EndingVpn));
             ON_CALL(*mockVmiInterface, getKernelStructOffset("_MMVAD_SHORT", "EndingVpnHigh"))
-                .WillByDefault(Return(__MMVAD_SHORT_OFFSETS::EndingVpnHigh));
+                .WillByDefault(testing::Return(__MMVAD_SHORT_OFFSETS::EndingVpnHigh));
             ON_CALL(*mockVmiInterface, getKernelStructOffset("_MMVAD_SHORT", "u"))
-                .WillByDefault(Return(__MMVAD_SHORT_OFFSETS::Flags));
+                .WillByDefault(testing::Return(__MMVAD_SHORT_OFFSETS::Flags));
             ON_CALL(*mockVmiInterface, getKernelStructOffset("_MMVAD", "Core"))
-                .WillByDefault(Return(_MMVAD_OFFSETS::BaseAddress));
+                .WillByDefault(testing::Return(_MMVAD_OFFSETS::BaseAddress));
             ON_CALL(*mockVmiInterface, getKernelStructOffset("_MMVAD", "Subsection"))
-                .WillByDefault(Return(_MMVAD_OFFSETS::Subsection));
+                .WillByDefault(testing::Return(_MMVAD_OFFSETS::Subsection));
             ON_CALL(*mockVmiInterface, getKernelStructOffset("_SUBSECTION", "ControlArea"))
-                .WillByDefault(Return(_SUBSECTION_OFFSETS::ControlArea));
+                .WillByDefault(testing::Return(_SUBSECTION_OFFSETS::ControlArea));
             ON_CALL(*mockVmiInterface, getKernelStructOffset("_EX_FAST_REF", "Object"))
-                .WillByDefault(Return(_EX_FAST_REF_OFFSETS::Object));
+                .WillByDefault(testing::Return(_EX_FAST_REF_OFFSETS::Object));
             ON_CALL(*mockVmiInterface, getKernelStructOffset("_RTL_BALANCED_NODE", "Left"))
-                .WillByDefault(Return(_RTL_BALANCED_NODE_OFFSETS::Left));
+                .WillByDefault(testing::Return(_RTL_BALANCED_NODE_OFFSETS::Left));
             ON_CALL(*mockVmiInterface, getKernelStructOffset("_RTL_BALANCED_NODE", "Right"))
-                .WillByDefault(Return(_RTL_BALANCED_NODE_OFFSETS::Right));
-            ON_CALL(*mockVmiInterface, isInitialized()).WillByDefault(Return(true));
+                .WillByDefault(testing::Return(_RTL_BALANCED_NODE_OFFSETS::Right));
+            ON_CALL(*mockVmiInterface, isInitialized()).WillByDefault(testing::Return(true));
             ON_CALL(*mockVmiInterface, getBitfieldOffsetAndSizeFromJson("_MMSECTION_FLAGS", "BeingDeleted"))
-                .WillByDefault(Return(std::make_tuple(0, SECTION_FLAGS_OFFSETS::beingDeleted, 1)));
+                .WillByDefault(testing::Return(std::make_tuple(0, SECTION_FLAGS_OFFSETS::beingDeleted, 1)));
             ON_CALL(*mockVmiInterface, getBitfieldOffsetAndSizeFromJson("_MMSECTION_FLAGS", "Image"))
-                .WillByDefault(Return(std::make_tuple(0, SECTION_FLAGS_OFFSETS::image, 6)));
+                .WillByDefault(testing::Return(std::make_tuple(0, SECTION_FLAGS_OFFSETS::image, 6)));
             ON_CALL(*mockVmiInterface, getBitfieldOffsetAndSizeFromJson("_MMSECTION_FLAGS", "File"))
-                .WillByDefault(Return(std::make_tuple(0, SECTION_FLAGS_OFFSETS::file, 8)));
+                .WillByDefault(testing::Return(std::make_tuple(0, SECTION_FLAGS_OFFSETS::file, 8)));
             ON_CALL(*mockVmiInterface, getBitfieldOffsetAndSizeFromJson("_MMVAD_FLAGS", "Protection"))
-                .WillByDefault(Return(std::make_tuple(0, MMVAD_FLAGS_OFFSETS::protection, 12)));
+                .WillByDefault(testing::Return(std::make_tuple(0, MMVAD_FLAGS_OFFSETS::protection, 12)));
             ON_CALL(*mockVmiInterface, getBitfieldOffsetAndSizeFromJson("_MMVAD_FLAGS", "PrivateMemory"))
-                .WillByDefault(Return(std::make_tuple(0, MMVAD_FLAGS_OFFSETS::privateMemory, 21)));
+                .WillByDefault(testing::Return(std::make_tuple(0, MMVAD_FLAGS_OFFSETS::privateMemory, 21)));
             ON_CALL(*mockVmiInterface, getStructSizeFromJson(Windows::KernelStructOffsets::mmvad_flags::structName))
-                .WillByDefault(Return(4));
+                .WillByDefault(testing::Return(4));
             ON_CALL(*mockVmiInterface, getStructSizeFromJson(Windows::KernelStructOffsets::mmsection_flags::structName))
-                .WillByDefault(Return(4));
+                .WillByDefault(testing::Return(4));
         }
 
         void setupProcessWithLink(const processValues& process, uint64_t linkEprocessBase)
         {
             ON_CALL(*mockVmiInterface, read32VA(process.eprocessBase + _EPROCESS_OFFSETS::ExitStatus, systemCR3))
-                .WillByDefault(Return(process.exitStatus));
+                .WillByDefault(testing::Return(process.exitStatus));
             ON_CALL(*mockVmiInterface,
                     read64VA(process.eprocessBase + _EPROCESS_OFFSETS::ActiveProcessLinks, systemCR3))
-                .WillByDefault(Return(linkEprocessBase + _EPROCESS_OFFSETS::ActiveProcessLinks));
+                .WillByDefault(testing::Return(linkEprocessBase + _EPROCESS_OFFSETS::ActiveProcessLinks));
             ON_CALL(*mockVmiInterface,
                     extractStringAtVA(process.eprocessBase + _EPROCESS_OFFSETS::ImageFileName, systemCR3))
                 .WillByDefault([process = process](uint64_t, uint64_t)
                                { return std::make_unique<std::string>(process.imageFileName); });
             ON_CALL(*mockVmiInterface, read32VA(process.eprocessBase + _EPROCESS_OFFSETS::UniqueProcessId, systemCR3))
-                .WillByDefault(Return(process.processId));
+                .WillByDefault(testing::Return(process.processId));
             ON_CALL(*mockVmiInterface,
                     read64VA(process.eprocessBase + _KPROCESS_OFFSETS::DirectoryTableBase, systemCR3))
-                .WillByDefault(Return(process.directoryTableBase));
+                .WillByDefault(testing::Return(process.directoryTableBase));
         }
 
         void setupActiveProcessList(const std::vector<processValues>& processes)
         {
             uint64_t psActiveProcessHeadVAReturn = processes[0].eprocessBase + _EPROCESS_OFFSETS::ActiveProcessLinks;
             ON_CALL(*mockVmiInterface, translateKernelSymbolToVA("PsActiveProcessHead"))
-                .WillByDefault(Return(psActiveProcessHeadVAReturn));
+                .WillByDefault(testing::Return(psActiveProcessHeadVAReturn));
 
             for (auto process = processes.cbegin(); process != processes.cend()--; process++)
             {
@@ -301,9 +298,9 @@ namespace VmiCore
         void setupExtractProcessPathReturns(const processValues& process)
         {
             ON_CALL(*mockVmiInterface, read64VA(process.eprocessBase + _EPROCESS_OFFSETS::SectionObject, systemCR3))
-                .WillByDefault(Return(process.sectionAddress));
+                .WillByDefault(testing::Return(process.sectionAddress));
             ON_CALL(*mockVmiInterface, read64VA(process.sectionAddress + _SECTION_OFFSETS::ControlArea, systemCR3))
-                .WillByDefault(Return(process.controlAreaAddress));
+                .WillByDefault(testing::Return(process.controlAreaAddress));
             ON_CALL(*mockVmiInterface,
                     read64VA(process.controlAreaAddress + _CONTROL_AREA_OFFSETS::MMSECTION_FLAGS, systemCR3))
                 .WillByDefault([processSectionFlags = process.sectionFlags](uint64_t, uint64_t)
@@ -314,7 +311,7 @@ namespace VmiCore
                                { return processSectionFlags; });
             ON_CALL(*mockVmiInterface,
                     read64VA(process.controlAreaAddress + _CONTROL_AREA_OFFSETS::FilePointer, systemCR3))
-                .WillByDefault(Return(process.filePointerAddress));
+                .WillByDefault(testing::Return(process.filePointerAddress));
             ON_CALL(*mockVmiInterface,
                     extractUnicodeStringAtVA(process.filePointerAddress + _FILE_OBJECT_OFFSETS::FileName, systemCR3))
                 .WillByDefault([processFilePath = process.filePath](uint64_t, uint64_t)
@@ -325,9 +322,9 @@ namespace VmiCore
         {
             ON_CALL(*mockVmiInterface,
                     read64VA(process.eprocessBase + _KPROCESS_OFFSETS::DirectoryTableBase, systemCR3))
-                .WillByDefault(Return(process.cr3));
+                .WillByDefault(testing::Return(process.cr3));
             ON_CALL(*mockVmiInterface, read32VA(process.eprocessBase + _EPROCESS_OFFSETS::UniqueProcessId, systemCR3))
-                .WillByDefault(Return(process.processId));
+                .WillByDefault(testing::Return(process.processId));
             ON_CALL(*mockVmiInterface,
                     extractStringAtVA(process.eprocessBase + _EPROCESS_OFFSETS::ImageFileName, systemCR3))
                 .WillByDefault([processFileName = process.imageFileName](uint64_t, uint64_t)
@@ -341,16 +338,16 @@ namespace VmiCore
         }
 
         std::filesystem::path pluginDirectory = "/var/lib/test";
-        std::shared_ptr<NiceMock<MockConfigInterface>> mockConfigInterface =
-            std::make_shared<NiceMock<MockConfigInterface>>();
-        std::shared_ptr<NiceMock<MockLegacyLogging>> mockLegacyLogging =
-            std::make_shared<NiceMock<MockLegacyLogging>>();
+        std::shared_ptr<testing::NiceMock<MockConfigInterface>> mockConfigInterface =
+            std::make_shared<testing::NiceMock<MockConfigInterface>>();
+        std::shared_ptr<testing::NiceMock<MockLegacyLogging>> mockLegacyLogging =
+            std::make_shared<testing::NiceMock<MockLegacyLogging>>();
 
         std::shared_ptr<PluginSystem> pluginSystem;
 
         void setupReturnsForConfigInterface()
         {
-            ON_CALL(*mockConfigInterface, getPluginDirectory()).WillByDefault(Return(pluginDirectory));
+            ON_CALL(*mockConfigInterface, getPluginDirectory()).WillByDefault(testing::Return(pluginDirectory));
         }
 
         uint64_t vadRootNodeBase = 666 + PagingDefinitions::kernelspaceLowerBoundary;
@@ -415,31 +412,31 @@ namespace VmiCore
         void systemVadTreeRootNodeMemoryState()
         {
             ON_CALL(*mockVmiInterface, read64VA(process4.eprocessBase + _EPROCESS_OFFSETS::VadRoot, systemCR3))
-                .WillByDefault(Return(vadRootNodeBase));
+                .WillByDefault(testing::Return(vadRootNodeBase));
             ON_CALL(*mockVmiInterface,
                     read64VA(vadRootNodeBase + _MMVAD_OFFSETS::BaseAddress + __MMVAD_SHORT_OFFSETS::VadNode +
                                  _RTL_BALANCED_NODE_OFFSETS::Left,
                              systemCR3))
-                .WillByDefault(Return(vadRootNodeLeftChildBase));
+                .WillByDefault(testing::Return(vadRootNodeLeftChildBase));
             ON_CALL(*mockVmiInterface,
                     read64VA(vadRootNodeBase + _MMVAD_OFFSETS::BaseAddress + __MMVAD_SHORT_OFFSETS::VadNode +
                                  _RTL_BALANCED_NODE_OFFSETS::Right,
                              systemCR3))
-                .WillByDefault(Return(vadRootNodeRightChildBase));
+                .WillByDefault(testing::Return(vadRootNodeRightChildBase));
             ON_CALL(*mockVmiInterface, read8VA(vadRootNodeBase + __MMVAD_SHORT_OFFSETS::StartingVpnHigh, systemCR3))
-                .WillByDefault(Return(vadRootNodeStartingVpnHigh));
+                .WillByDefault(testing::Return(vadRootNodeStartingVpnHigh));
             ON_CALL(*mockVmiInterface, read8VA(vadRootNodeBase + __MMVAD_SHORT_OFFSETS::EndingVpnHigh, systemCR3))
-                .WillByDefault(Return(vadRootNodeEndingVpnHigh));
+                .WillByDefault(testing::Return(vadRootNodeEndingVpnHigh));
             ON_CALL(*mockVmiInterface, read32VA(vadRootNodeBase + __MMVAD_SHORT_OFFSETS::StartingVpn, systemCR3))
-                .WillByDefault(Return(vadRootNodeStartingVpn));
+                .WillByDefault(testing::Return(vadRootNodeStartingVpn));
             ON_CALL(*mockVmiInterface, read32VA(vadRootNodeBase + __MMVAD_SHORT_OFFSETS::EndingVpn, systemCR3))
-                .WillByDefault(Return(vadRootNodeEndingVpn));
+                .WillByDefault(testing::Return(vadRootNodeEndingVpn));
             ON_CALL(*mockVmiInterface, read64VA(vadRootNodeBase + __MMVAD_SHORT_OFFSETS::Flags, systemCR3))
-                .WillByDefault(
-                    Return(createMmvadFlags(static_cast<uint32_t>(Windows::ProtectionValues::MM_READWRITE), true)));
+                .WillByDefault(testing::Return(
+                    createMmvadFlags(static_cast<uint32_t>(Windows::ProtectionValues::MM_READWRITE), true)));
             ON_CALL(*mockVmiInterface, read32VA(vadRootNodeBase + __MMVAD_SHORT_OFFSETS::Flags, systemCR3))
-                .WillByDefault(
-                    Return(createMmvadFlags(static_cast<uint32_t>(Windows::ProtectionValues::MM_READWRITE), true)));
+                .WillByDefault(testing::Return(
+                    createMmvadFlags(static_cast<uint32_t>(Windows::ProtectionValues::MM_READWRITE), true)));
         }
 
         void systemVadTreeRightChildOfRootNodeMemoryState()
@@ -452,45 +449,45 @@ namespace VmiCore
                     read64VA(vadRootNodeRightChildBase + _MMVAD_OFFSETS::BaseAddress + __MMVAD_SHORT_OFFSETS::VadNode +
                                  _RTL_BALANCED_NODE_OFFSETS::Left,
                              systemCR3))
-                .WillByDefault(Return(0));
+                .WillByDefault(testing::Return(0));
             ON_CALL(*mockVmiInterface,
                     read64VA(vadRootNodeRightChildBase + _MMVAD_OFFSETS::BaseAddress + __MMVAD_SHORT_OFFSETS::VadNode +
                                  _RTL_BALANCED_NODE_OFFSETS::Right,
                              systemCR3))
-                .WillByDefault(Return(0));
+                .WillByDefault(testing::Return(0));
             ON_CALL(*mockVmiInterface,
                     read8VA(vadRootNodeRightChildBase + __MMVAD_SHORT_OFFSETS::StartingVpnHigh, systemCR3))
-                .WillByDefault(Return(0));
+                .WillByDefault(testing::Return(0));
             ON_CALL(*mockVmiInterface,
                     read8VA(vadRootNodeRightChildBase + __MMVAD_SHORT_OFFSETS::EndingVpnHigh, systemCR3))
-                .WillByDefault(Return(0));
+                .WillByDefault(testing::Return(0));
             ON_CALL(*mockVmiInterface,
                     read32VA(vadRootNodeRightChildBase + __MMVAD_SHORT_OFFSETS::StartingVpn, systemCR3))
-                .WillByDefault(Return(vadRootNodeRightChildStartingVpn));
+                .WillByDefault(testing::Return(vadRootNodeRightChildStartingVpn));
             ON_CALL(*mockVmiInterface,
                     read32VA(vadRootNodeRightChildBase + __MMVAD_SHORT_OFFSETS::EndingVpn, systemCR3))
-                .WillByDefault(Return(vadRootNodeRightChildEndingVpn));
+                .WillByDefault(testing::Return(vadRootNodeRightChildEndingVpn));
             ON_CALL(*mockVmiInterface, read32VA(vadRootNodeRightChildBase + __MMVAD_SHORT_OFFSETS::Flags, systemCR3))
-                .WillByDefault(Return(
+                .WillByDefault(testing::Return(
                     createMmvadFlags(static_cast<uint32_t>(Windows::ProtectionValues::MM_EXECUTE_WRITECOPY), false)));
             ON_CALL(*mockVmiInterface, read64VA(vadRootNodeRightChildBase + _MMVAD_OFFSETS::Subsection, systemCR3))
-                .WillByDefault(Return(subsectionAddress));
+                .WillByDefault(testing::Return(subsectionAddress));
             ON_CALL(*mockVmiInterface, read64VA(subsectionAddress + _SUBSECTION_OFFSETS::ControlArea, systemCR3))
-                .WillByDefault(Return(controlAreaAddress));
+                .WillByDefault(testing::Return(controlAreaAddress));
             ON_CALL(*mockVmiInterface, read64VA(controlAreaAddress + _CONTROL_AREA_OFFSETS::MMSECTION_FLAGS, systemCR3))
-                .WillByDefault(Return(process4.sectionFlags));
+                .WillByDefault(testing::Return(process4.sectionFlags));
             ON_CALL(*mockVmiInterface, read32VA(controlAreaAddress + _CONTROL_AREA_OFFSETS::MMSECTION_FLAGS, systemCR3))
-                .WillByDefault(Return(process4.sectionFlags));
+                .WillByDefault(testing::Return(process4.sectionFlags));
             ON_CALL(*mockVmiInterface,
                     read64VA(controlAreaAddress + _CONTROL_AREA_OFFSETS::FilePointer + _EX_FAST_REF_OFFSETS::Object,
                              systemCR3))
-                .WillByDefault(Return(filePointerObjectAddress));
+                .WillByDefault(testing::Return(filePointerObjectAddress));
             ON_CALL(*mockVmiInterface,
                     extractUnicodeStringAtVA((filePointerObjectAddress) + _FILE_OBJECT_OFFSETS::FileName, systemCR3))
                 .WillByDefault([fileNameString = fileNameString](uint64_t, uint64_t)
                                { return std::make_unique<std::string>(fileNameString); });
             ON_CALL(*mockVmiInterface, read64VA(process4.eprocessBase + _EPROCESS_OFFSETS::ImageFilePointer, systemCR3))
-                .WillByDefault(Return(filePointerObjectAddress));
+                .WillByDefault(testing::Return(filePointerObjectAddress));
         }
 
         void systemVadTreeLeftChildOfRootNodeMemoryState()
@@ -499,12 +496,12 @@ namespace VmiCore
                     read64VA(vadRootNodeLeftChildBase + _MMVAD_OFFSETS::BaseAddress + __MMVAD_SHORT_OFFSETS::VadNode +
                                  _RTL_BALANCED_NODE_OFFSETS::Left,
                              systemCR3))
-                .WillByDefault(Return(0));
+                .WillByDefault(testing::Return(0));
             ON_CALL(*mockVmiInterface,
                     read64VA(vadRootNodeLeftChildBase + _MMVAD_OFFSETS::BaseAddress + __MMVAD_SHORT_OFFSETS::VadNode +
                                  _RTL_BALANCED_NODE_OFFSETS::Right,
                              systemCR3))
-                .WillByDefault(Return(vadRootNodeBase));
+                .WillByDefault(testing::Return(vadRootNodeBase));
             ON_CALL(*mockVmiInterface,
                     read8VA(vadRootNodeLeftChildBase + __MMVAD_SHORT_OFFSETS::StartingVpnHigh, systemCR3))
                 .WillByDefault([vadLeftChildStartingVpn = vadRootNodeLeftChildStartingVpn](uint64_t, uint64_t)
@@ -515,15 +512,15 @@ namespace VmiCore
                                { return vadLeftChildEndingVpn >> 32; });
             ON_CALL(*mockVmiInterface,
                     read32VA(vadRootNodeLeftChildBase + __MMVAD_SHORT_OFFSETS::StartingVpn, systemCR3))
-                .WillByDefault(Return(vadRootNodeLeftChildStartingVpn));
+                .WillByDefault(testing::Return(vadRootNodeLeftChildStartingVpn));
             ON_CALL(*mockVmiInterface, read32VA(vadRootNodeLeftChildBase + __MMVAD_SHORT_OFFSETS::EndingVpn, systemCR3))
-                .WillByDefault(Return(vadRootNodeLeftChildEndingVpn));
+                .WillByDefault(testing::Return(vadRootNodeLeftChildEndingVpn));
             ON_CALL(*mockVmiInterface, read64VA(vadRootNodeLeftChildBase + __MMVAD_SHORT_OFFSETS::Flags, systemCR3))
-                .WillByDefault(
-                    Return(createMmvadFlags(static_cast<uint32_t>(Windows::ProtectionValues::MM_READWRITE), true)));
+                .WillByDefault(testing::Return(
+                    createMmvadFlags(static_cast<uint32_t>(Windows::ProtectionValues::MM_READWRITE), true)));
             ON_CALL(*mockVmiInterface, read32VA(vadRootNodeLeftChildBase + __MMVAD_SHORT_OFFSETS::Flags, systemCR3))
-                .WillByDefault(
-                    Return(createMmvadFlags(static_cast<uint32_t>(Windows::ProtectionValues::MM_READWRITE), true)));
+                .WillByDefault(testing::Return(
+                    createMmvadFlags(static_cast<uint32_t>(Windows::ProtectionValues::MM_READWRITE), true)));
         }
 
         static uint32_t createMmvadFlags(uint32_t protection, bool privateMemory)
@@ -572,7 +569,7 @@ namespace VmiCore
                                                           interruptEventSupervisor,
                                                           mockLegacyLogging,
                                                           mockLogging,
-                                                          std::make_shared<NiceMock<MockEventStream>>());
+                                                          std::make_shared<testing::NiceMock<MockEventStream>>());
         };
     };
 }

--- a/vmicore/test/lib/vmi/SingleStepSupervisor_UnitTest.cpp
+++ b/vmicore/test/lib/vmi/SingleStepSupervisor_UnitTest.cpp
@@ -18,7 +18,7 @@ namespace VmiCore
     {
         std::shared_ptr<NiceMock<MockLogging>> mockLogging = std::make_shared<NiceMock<MockLogging>>();
         ON_CALL(*mockLogging, newNamedLogger(_))
-            .WillByDefault([](const std::string_view&) { return std::make_unique<MockGRPCLogger>(); });
+            .WillByDefault([](std::string_view) { return std::make_unique<MockGRPCLogger>(); });
 
         std::shared_ptr<ILibvmiInterface> vmiInterface = std::make_shared<MockLibvmiInterface>();
         SingleStepSupervisor firstInstance(vmiInterface, mockLogging);
@@ -44,7 +44,7 @@ namespace VmiCore
         void SetUp() override
         {
             ON_CALL(*mockLogging, newNamedLogger(_))
-                .WillByDefault([](const std::string_view&) { return std::make_unique<MockGRPCLogger>(); });
+                .WillByDefault([](std::string_view) { return std::make_unique<MockGRPCLogger>(); });
 
             ON_CALL(*vmiInterface, getNumberOfVCPUs()).WillByDefault(Return(numberOfTestVcpus));
             singleStepSupervisor = std::make_unique<SingleStepSupervisor>(vmiInterface, mockLogging);


### PR DESCRIPTION
Use rust's `str` instead of `CxxString` for rust interface functions. Let the C++ code handle conversions from `std::string_view` to `rust::Str`. Furthermore, always pass `std::string_view` by value.