### PR TITLE
Use separate mutex for eventsListen

### DIFF
--- a/vmicore/src/lib/vmi/LibvmiInterface.cpp
+++ b/vmicore/src/lib/vmi/LibvmiInterface.cpp
@@ -1,6 +1,5 @@
 #include "LibvmiInterface.h"
 #include "../GlobalControl.h"
-#include "../os/PagingDefinitions.h"
 #include "VmiException.h"
 #include "VmiInitData.h"
 #include "VmiInitError.h"
@@ -38,7 +37,6 @@ namespace VmiCore
     void LibvmiInterface::initializeVmi()
     {
         logger->info("Initialize libvmi", {logfield::create("domain", configInterface->getVmName())});
-        logger->info("Initialize successfully initialized", {logfield::create("domain", configInterface->getVmName())});
 
         auto configString = createConfigString(configInterface->getOffsetsFile());
         auto initData = VmiInitData(configInterface->getSocketPath());
@@ -187,7 +185,7 @@ namespace VmiCore
 
     void LibvmiInterface::eventsListen(uint32_t timeout)
     {
-        std::lock_guard<std::mutex> lock(libvmiLock);
+        std::lock_guard<std::mutex> lock(eventsListenLock);
         auto status = vmi_events_listen(vmiInstance, timeout);
         if (status != VMI_SUCCESS)
         {

--- a/vmicore/src/lib/vmi/LibvmiInterface.h
+++ b/vmicore/src/lib/vmi/LibvmiInterface.h
@@ -145,6 +145,7 @@ namespace VmiCore
         std::shared_ptr<IEventStream> eventStream;
         vmi_instance_t vmiInstance{};
         std::mutex libvmiLock{};
+        std::mutex eventsListenLock{};
 
         static std::unique_ptr<std::string> createConfigString(const std::string& offsetsFile);
 


### PR DESCRIPTION
Avoid deadlock since libvmi might call user callbacks which in turn might call other libvmiInterface functions therefore causing a deadlock.