### PR TITLE
Remove pedantic flag

### DIFF
--- a/vmicore/CMakeLists.txt
+++ b/vmicore/CMakeLists.txt
@@ -12,7 +12,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 add_subdirectory(src)
 target_compile_definitions(vmicore PRIVATE PROGRAM_VERSION="${VMICORE_PROGRAM_VERSION}" BUILD_VERSION="${VMICORE_PROGRAM_BUILD_NUMBER}")
-target_compile_options(vmicore-lib PUBLIC -Wall -Wunused -Wunreachable-code -Wextra -Wpedantic -Wno-dollar-in-identifier-extension)
+target_compile_options(vmicore-lib PUBLIC -Wall -Wunused -Wunreachable-code -Wextra)
 
 if (VMICORE_TRACE_MODE)
     target_compile_definitions(vmicore-lib PRIVATE TRACE_MODE)


### PR DESCRIPTION
The pedantic flag warns about compiler extensions. Since these are widely used in the projects that we depend on it makes sense to remove this flag in order to improve visibility for other warnings.