### PR TITLE
Do not pause vm in deleteBreakpoint()

### DIFF
--- a/vmicore/src/lib/vmi/InterruptEventSupervisor.cpp
+++ b/vmicore/src/lib/vmi/InterruptEventSupervisor.cpp
@@ -132,8 +132,6 @@ namespace VmiCore
         if (breakpointsAtPA->second.empty())
         {
             breakpointsAtGFN->second.Breakpoints.erase(breakpointsAtPA);
-            // Prevent new events from happening while we are removing the INT3 from memory
-            vmiInterface->pauseVm();
 
             if (vmiInterface->areEventsPending())
             {
@@ -149,8 +147,6 @@ namespace VmiCore
                 breakpointsAtGFN->second.PageGuard->teardown();
                 breakpointsByGFN.erase(breakpointsAtGFN);
             }
-
-            vmiInterface->resumeVm();
         }
     }
 

--- a/vmicore/test/CMakeLists.txt
+++ b/vmicore/test/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(vmicore-test
         lib/vmi/InterruptEventSupervisor_UnitTest.cpp
         lib/vmi/LibvmiInterface_UnitTest.cpp
         lib/vmi/SingleStepSupervisor_UnitTest.cpp)
+target_compile_options(vmicore-test PRIVATE -Wno-missing-field-initializers)
 target_link_libraries(vmicore-test vmicore-lib pthread)
 
 # Setup bundled google test framework

--- a/vmicore/test/lib/vmi/InterruptEventSupervisor_UnitTest.cpp
+++ b/vmicore/test/lib/vmi/InterruptEventSupervisor_UnitTest.cpp
@@ -353,20 +353,6 @@ namespace VmiCore
     }
 
     TEST_F(InterruptEventFixtureWithoutInterruptEventSupervisorTeardown,
-           deleteBreakpoint_singleBreakpoint_vmPausedAndResumed)
-    {
-        setupBreakpoint(testVA1, testPA1, testSystemCr3, testOriginalMemoryContent);
-        auto breakpoint = interruptEventSupervisor->createBreakpoint(
-            testVA1, testSystemCr3, mockBreakpointCallback->AsStdFunction(), true);
-        testing::Sequence s1;
-        EXPECT_CALL(*vmiInterface, pauseVm()).Times(1).InSequence(s1);
-        EXPECT_CALL(*vmiInterface, write8PA(testPA1, testOriginalMemoryContent)).Times(1).InSequence(s1);
-        EXPECT_CALL(*vmiInterface, resumeVm()).Times(1).InSequence(s1);
-
-        interruptEventSupervisor->deleteBreakpoint(breakpoint.get());
-    }
-
-    TEST_F(InterruptEventFixtureWithoutInterruptEventSupervisorTeardown,
            deleteBreakpoint_noPendingEvents_eventsListenNotCalled)
     {
         setupBreakpoint(testVA1, testPA1, testSystemCr3, testOriginalMemoryContent);


### PR DESCRIPTION
Pausing VMs during an event callback will cause a deadlock. Since there isn't a likely scenario where `deleteBreakpoint()` will not be called from within an event callback, we might as well remove `pauseVm()` here.