### PR TITLE
Replace std::list with std::vector in MemoryRegionExtractor

### DIFF
--- a/vmicore/src/include/vmicore/os/IMemoryRegionExtractor.h
+++ b/vmicore/src/include/vmicore/os/IMemoryRegionExtractor.h
@@ -2,8 +2,8 @@
 #define VMICORE_IMEMORYREGIONEXTRACTOR_H
 
 #include "MemoryRegion.h"
-#include <list>
 #include <memory>
+#include <vector>
 
 namespace VmiCore
 {
@@ -12,7 +12,7 @@ namespace VmiCore
       public:
         virtual ~IMemoryRegionExtractor() = default;
 
-        [[nodiscard]] virtual std::unique_ptr<std::list<MemoryRegion>> extractAllMemoryRegions() const = 0;
+        [[nodiscard]] virtual std::unique_ptr<std::vector<MemoryRegion>> extractAllMemoryRegions() const = 0;
 
       protected:
         IMemoryRegionExtractor() = default;

--- a/vmicore/src/lib/os/linux/MMExtractor.cpp
+++ b/vmicore/src/lib/os/linux/MMExtractor.cpp
@@ -16,9 +16,9 @@ namespace VmiCore::Linux
     {
     }
 
-    std::unique_ptr<std::list<MemoryRegion>> MMExtractor::extractAllMemoryRegions() const
+    std::unique_ptr<std::vector<MemoryRegion>> MMExtractor::extractAllMemoryRegions() const
     {
-        auto regions = std::make_unique<std::list<MemoryRegion>>();
+        auto regions = std::make_unique<std::vector<MemoryRegion>>();
 
         for (auto area = vmiInterface->read64VA(mm, vmiInterface->convertPidToDtb(SYSTEM_PID)); area != 0;
              area = vmiInterface->read64VA(area + vmiInterface->getKernelStructOffset("vm_area_struct", "vm_next"),

--- a/vmicore/src/lib/os/linux/MMExtractor.h
+++ b/vmicore/src/lib/os/linux/MMExtractor.h
@@ -16,7 +16,7 @@ namespace VmiCore::Linux
                     const std::shared_ptr<ILogging>& logging,
                     uint64_t mm);
 
-        [[nodiscard]] std::unique_ptr<std::list<MemoryRegion>> extractAllMemoryRegions() const override;
+        [[nodiscard]] std::unique_ptr<std::vector<MemoryRegion>> extractAllMemoryRegions() const override;
 
       private:
         std::shared_ptr<ILibvmiInterface> vmiInterface;

--- a/vmicore/src/lib/os/windows/VadTreeWin10.cpp
+++ b/vmicore/src/lib/os/windows/VadTreeWin10.cpp
@@ -22,9 +22,9 @@ namespace VmiCore::Windows
     {
     }
 
-    std::unique_ptr<std::list<MemoryRegion>> VadTreeWin10::extractAllMemoryRegions() const
+    std::unique_ptr<std::vector<MemoryRegion>> VadTreeWin10::extractAllMemoryRegions() const
     {
-        auto regions = std::make_unique<std::list<MemoryRegion>>();
+        auto regions = std::make_unique<std::vector<MemoryRegion>>();
         std::list<uint64_t> nextVadEntries;
         std::unordered_set<uint64_t> visitedVadVAs;
         auto nodeAddress = kernelAccess->extractVadTreeRootAddress(eprocessBase);

--- a/vmicore/src/lib/os/windows/VadTreeWin10.h
+++ b/vmicore/src/lib/os/windows/VadTreeWin10.h
@@ -21,7 +21,7 @@ namespace VmiCore::Windows
                      std::string processName,
                      const std::shared_ptr<ILogging>& logging);
 
-        [[nodiscard]] std::unique_ptr<std::list<MemoryRegion>> extractAllMemoryRegions() const override;
+        [[nodiscard]] std::unique_ptr<std::vector<MemoryRegion>> extractAllMemoryRegions() const override;
 
       private:
         std::shared_ptr<IKernelAccess> kernelAccess;

--- a/vmicore/test/include/vmicore_test/os/mock_MemoryRegionExtractor.h
+++ b/vmicore/test/include/vmicore_test/os/mock_MemoryRegionExtractor.h
@@ -9,7 +9,7 @@ namespace VmiCore
     class MockMemoryRegionExtractor : public IMemoryRegionExtractor
     {
       public:
-        MOCK_METHOD(std::unique_ptr<std::list<MemoryRegion>>, extractAllMemoryRegions, (), (const override));
+        MOCK_METHOD(std::unique_ptr<std::vector<MemoryRegion>>, extractAllMemoryRegions, (), (const override));
     };
 }
 


### PR DESCRIPTION
https://dzone.com/articles/c-benchmark-%E2%80%93-stdvector-vs

TLDR: `std::vector` is almost always better than `std::list`, except for a few special cases such as always inserting elements at the front or handling large elements.