### PR TITLE
plugin-interface: use `extern "C"` for plugin init function

### DIFF
--- a/plugins/apitracing/src/lib/ApiTracing.cpp
+++ b/plugins/apitracing/src/lib/ApiTracing.cpp
@@ -99,10 +99,10 @@ namespace ApiTracing
     }
 }
 
-std::unique_ptr<IPlugin>
-VmiCore::Plugin::init(PluginInterface* pluginInterface,
-                      std::shared_ptr<IPluginConfig> config, // NOLINT(performance-unnecessary-value-param)
-                      std::vector<std::string> args)
+extern "C" std::unique_ptr<IPlugin> VmiCore::Plugin::vmicore_plugin_init(
+    PluginInterface* pluginInterface,
+    std::shared_ptr<IPluginConfig> config, // NOLINT(performance-unnecessary-value-param)
+    std::vector<std::string> args)
 {
     return std::make_unique<ApiTracing::ApiTracing>(pluginInterface, *config, args);
 }

--- a/plugins/inmemoryscanner/src/lib/InMemory.cpp
+++ b/plugins/inmemoryscanner/src/lib/InMemory.cpp
@@ -66,10 +66,10 @@ namespace InMemoryScanner
     }
 }
 
-std::unique_ptr<IPlugin>
-VmiCore::Plugin::init(PluginInterface* pluginInterface,
-                      std::shared_ptr<IPluginConfig> config, // NOLINT(performance-unnecessary-value-param)
-                      std::vector<std::string> args)
+extern "C" std::unique_ptr<IPlugin> VmiCore::Plugin::vmicore_plugin_init(
+    PluginInterface* pluginInterface,
+    std::shared_ptr<IPluginConfig> config, // NOLINT(performance-unnecessary-value-param)
+    std::vector<std::string> args)
 {
     return std::make_unique<InMemoryScanner::InMemory>(pluginInterface, *config, args);
 }

--- a/plugins/template/src/lib/Template.cpp
+++ b/plugins/template/src/lib/Template.cpp
@@ -51,12 +51,13 @@ namespace Template
     }
 }
 
-// This is the init function. It is called by VmiCore and is responsible for creating an instance of a plugin.
+// This is the init function. It is linked and called dynamically at runtime by
+// VmiCore and is responsible for creating an instance of a plugin.
 // All plugins have to inherit from IPlugin.
-std::unique_ptr<IPlugin>
-VmiCore::Plugin::init(PluginInterface* pluginInterface,
-                      std::shared_ptr<IPluginConfig> config, // NOLINT(performance-unnecessary-value-param)
-                      std::vector<std::string> args)
+extern "C" std::unique_ptr<IPlugin> VmiCore::Plugin::vmicore_plugin_init(
+    PluginInterface* pluginInterface,
+    std::shared_ptr<IPluginConfig> config, // NOLINT(performance-unnecessary-value-param)
+    std::vector<std::string> args)
 {
     return std::make_unique<Template::Template>(pluginInterface, *config, args);
 }

--- a/vmicore/src/include/vmicore/plugins/IPlugin.h
+++ b/vmicore/src/include/vmicore/plugins/IPlugin.h
@@ -44,8 +44,9 @@ namespace VmiCore::Plugin
      * @param args Commandline arguments passed to this specific plugin. Elements are whitespace separated.
      * @return An instance of the plugin. Has to implement the IPlugin interface. Lifetime will be managed by VMICore.
      */
-    extern std::unique_ptr<IPlugin>
-    init(PluginInterface* pluginInterface, std::shared_ptr<IPluginConfig> config, std::vector<std::string> args);
+    extern "C" std::unique_ptr<IPlugin> vmicore_plugin_init(PluginInterface* pluginInterface,
+                                                            std::shared_ptr<IPluginConfig> config,
+                                                            std::vector<std::string> args);
 }
 
 #endif // APITRACING_IPLUGIN_H

--- a/vmicore/src/lib/plugins/PluginSystem.cpp
+++ b/vmicore/src/lib/plugins/PluginSystem.cpp
@@ -161,10 +161,8 @@ namespace VmiCore
                                               Plugin::PluginInterface::API_VERSION));
         }
 
-        auto pluginInitFunction = std::bit_cast<decltype(Plugin::init)*>(
-            dlsym(libraryHandle,
-                  "_ZN7VmiCore6Plugin4initEPNS0_15PluginInterfaceENSt3__110shared_ptrINS0_13IPluginConfigEEENS3_"
-                  "6vectorINS3_12basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEENSB_ISD_EEEE"));
+        auto pluginInitFunction =
+            std::bit_cast<decltype(Plugin::vmicore_plugin_init)*>(dlsym(libraryHandle, PLUGIN_INIT_FUNCTION.data()));
         dlErrorMessage = dlerror();
         if (dlErrorMessage != nullptr)
         {

--- a/vmicore/src/lib/plugins/PluginSystem.h
+++ b/vmicore/src/lib/plugins/PluginSystem.h
@@ -17,6 +17,8 @@
 
 namespace VmiCore
 {
+    constexpr std::string_view PLUGIN_INIT_FUNCTION = "vmicore_plugin_init";
+
     class IPluginSystem : public Plugin::PluginInterface
     {
       public:


### PR DESCRIPTION
Currently, smartvmi loads plugins dynamically by loading their shared object. From that shared object, the main entry function is searched. The problem with that is that the current approach depends on the hard-coded C++-mangled symbol name. This however depends on the toolchain (compiler version etc.). Specifically, when compiled on NixOS, the name didn't match the upstream source code version.

As this symbol name is only relevant when loading a shared object into memory as part of the shared object's metadata analysis, this name doesn't have to be unique across plugins. Therefore, to get rid of the hardcoded symbol name, we use "extern C" to make things easier and more portable.

The function was renamed from "init" to "init_plugin" to have a more expressive name.

The disadvantage is that the caller can no longer implicitly verify the function signature used when the plugin was compiled.

However, with a few more assertions, we can mitigate this mostly.